### PR TITLE
Update hashdump.py

### DIFF
--- a/framework/win32/hashdump.py
+++ b/framework/win32/hashdump.py
@@ -256,7 +256,7 @@ def dump_hashes(sysaddr, samaddr):
         lmhash,nthash = get_user_hashes(user,hbootkey)
         if not lmhash: lmhash = empty_lm
         if not nthash: nthash = empty_nt
-        print "%s:%d:%s:%s:::" % (get_user_name(user), int(user.Name,16),
+        print "%s:%d:%s:%s:::" % (get_user_name(user).encode("utf-8"), int(user.Name,16),
                             lmhash.encode('hex'), nthash.encode('hex'))
 
 def dump_file_hashes(syshive_fname, samhive_fname):


### PR DESCRIPTION
The command "pwdump.py SYSTEM SAM > ~/hash.txt" will return a "UnicodeEncodeError" issue if a username contains a non-ascii character. This modification worked for me.

Exact error:

Traceback (most recent call last):
  File "/root/hashes/creddump7-master/pwdump.py", line 31, in <module>
    dump_file_hashes(sys.argv[1], sys.argv[2])
  File "/root/hashes/creddump7-master/framework/win32/hashdump.py", line 266, in dump_file_hashes
    dump_hashes(sysaddr, samaddr)
  File "/root/hashes/creddump7-master/framework/win32/hashdump.py", line 261, in dump_hashes
    lmhash.encode('hex'), nthash.encode('hex'))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 5: ordinal not in range(128)